### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Speak to Jira in natural language to get information on and modify your project.
 
 Built using the [Model Context Protocol](https://github.com/modelcontextprotocol).
 
+<a href="https://glama.ai/mcp/servers/lblw6pvk7i">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/lblw6pvk7i/badge" alt="Jira Server MCP server" />
+</a>
+
 The server enables:
 
 - Project creation and configuration


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server](https://glama.ai/mcp/servers/lblw6pvk7i) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/lblw6pvk7i">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/lblw6pvk7i/badge" alt="Jira Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.