### PR TITLE
Add support for JIRA server using v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Required environment variables:
 - `JIRA_API_TOKEN`: API token from https://id.atlassian.com/manage-profile/security/api-tokens OR Personal Access Token (PAT)
 - `JIRA_AUTH_TYPE`: Authentication type - either "basic" (default) or "bearer"
 
+Optional environment variables:
+
+- `JIRA_API_VERSION`: Jira API version to use (default: "3")
+
 **For Basic Authentication (default):**
 - `JIRA_EMAIL`: Your Jira account email (required when using basic auth)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,29 @@ The server enables:
 Required environment variables:
 
 - `JIRA_HOST`: Your Jira instance hostname
-- `JIRA_EMAIL`: Your Jira account email
-- `JIRA_API_TOKEN`: API token from https://id.atlassian.com/manage-profile/security/api-tokens
+- `JIRA_API_TOKEN`: API token from https://id.atlassian.com/manage-profile/security/api-tokens OR Personal Access Token (PAT)
+- `JIRA_AUTH_TYPE`: Authentication type - either "basic" (default) or "bearer"
+
+**For Basic Authentication (default):**
+- `JIRA_EMAIL`: Your Jira account email (required when using basic auth)
+
+**For Personal Access Token (PAT) Authentication:**
+- Set `JIRA_AUTH_TYPE=bearer` and provide your PAT as `JIRA_API_TOKEN`
+- `JIRA_EMAIL` is not required when using PAT
+
+### Personal Access Token Setup
+
+Personal Access Tokens (PATs) are the recommended authentication method for Jira Cloud as they provide better security than API tokens. To create a PAT:
+
+1. Go to your Jira instance settings
+2. Navigate to **Personal Access Tokens** (usually under **Security** or **Account Settings**)
+3. Click **Create token**
+4. Give your token a descriptive name (e.g., "Jira MCP Server")
+5. Set appropriate scopes/permissions (typically you'll need read and write access to projects and issues)
+6. Copy the generated token and use it as your `JIRA_API_TOKEN`
+7. Set `JIRA_AUTH_TYPE=bearer` in your configuration
+
+**Note:** PATs are not available for all Jira instances. If your instance doesn't support PATs, use the basic authentication method with your regular API token.
 
 ## Available Tools
 
@@ -206,10 +227,19 @@ The server provides detailed error messages for:
 3. Configure environment variables:
    Create a `.env` file in the root directory:
 
+   **For Basic Authentication (default):**
    ```bash
    JIRA_HOST=your-instance.atlassian.net
    JIRA_EMAIL=your-email@example.com
    JIRA_API_TOKEN=your-api-token
+   JIRA_AUTH_TYPE=basic
+   ```
+
+   **For Personal Access Token (PAT) Authentication:**
+   ```bash
+   JIRA_HOST=your-instance.atlassian.net
+   JIRA_API_TOKEN=your-personal-access-token
+   JIRA_AUTH_TYPE=bearer
    ```
 
 4. Build the project:
@@ -235,6 +265,7 @@ To use this MCP server with Claude Desktop:
 
 2. Add the Jira MCP server to your configuration:
 
+   **For Basic Authentication (default):**
    ```json
    {
      "mcpServers": {
@@ -246,7 +277,27 @@ To use this MCP server with Claude Desktop:
          "env": {
            "JIRA_HOST": "your-jira-instance.atlassian.net",
            "JIRA_EMAIL": "your-email@example.com",
-           "JIRA_API_TOKEN": "your-api-token"
+           "JIRA_API_TOKEN": "your-api-token",
+           "JIRA_AUTH_TYPE": "basic"
+         }
+       }
+     }
+   }
+   ```
+
+   **For Personal Access Token (PAT) Authentication:**
+   ```json
+   {
+     "mcpServers": {
+       "jira-server": {
+         "name": "jira-server",
+         "command": "/path/to/node",
+         "args": ["/path/to/jira-server/build/index.js"],
+         "cwd": "/path/to/jira-server",
+         "env": {
+           "JIRA_HOST": "your-jira-instance.atlassian.net",
+           "JIRA_API_TOKEN": "your-personal-access-token",
+           "JIRA_AUTH_TYPE": "bearer"
          }
        }
      }
@@ -269,6 +320,7 @@ To use this Jira MCP server with Cursor:
     - For global configuration (all projects): `~/.cursor/mcp.json` in your home directory.
 3.  **Add the Jira MCP server configuration to `mcp.json`:**
 
+    **For Basic Authentication (default):**
     ```json
     {
       "mcpServers": {
@@ -281,7 +333,29 @@ To use this Jira MCP server with Cursor:
           "env": {
             "JIRA_HOST": "your-jira-instance.atlassian.net",
             "JIRA_EMAIL": "your-email@example.com", // Your Jira email
-            "JIRA_API_TOKEN": "your-api-token" // Your Jira API token
+            "JIRA_API_TOKEN": "your-api-token", // Your Jira API token
+            "JIRA_AUTH_TYPE": "basic"
+          }
+        }
+        // You can add other MCP server configurations here
+      }
+    }
+    ```
+
+    **For Personal Access Token (PAT) Authentication:**
+    ```json
+    {
+      "mcpServers": {
+        "jira-mcp-server": {
+          "command": "node", // Or provide the absolute path to your Node.js executable
+          "args": [
+            "/path/to/your/Jira-MCP-Server/build/index.js" // Absolute path to the server's built index.js
+          ],
+          "cwd": "/path/to/your/Jira-MCP-Server", // Absolute path to the Jira-MCP-Server directory
+          "env": {
+            "JIRA_HOST": "your-jira-instance.atlassian.net",
+            "JIRA_API_TOKEN": "your-personal-access-token", // Your Jira PAT
+            "JIRA_AUTH_TYPE": "bearer"
           }
         }
         // You can add other MCP server configurations here
@@ -348,10 +422,19 @@ npx -y @smithery/cli install @George5562/Jira-MCP-Server --client claude
 3. Configure environment variables:
    Create a `.env` file in the root directory:
 
+   **For Basic Authentication (default):**
    ```bash
    JIRA_HOST=your-instance.atlassian.net
    JIRA_EMAIL=your-email@example.com
    JIRA_API_TOKEN=your-api-token
+   JIRA_AUTH_TYPE=basic
+   ```
+
+   **For Personal Access Token (PAT) Authentication:**
+   ```bash
+   JIRA_HOST=your-instance.atlassian.net
+   JIRA_API_TOKEN=your-personal-access-token
+   JIRA_AUTH_TYPE=bearer
    ```
 
 4. Build the project:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
+    "start": "node build/index.js",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,10 +80,17 @@ interface JiraIssueType {
 const JIRA_HOST = process.env.JIRA_HOST;
 const JIRA_EMAIL = process.env.JIRA_EMAIL;
 const JIRA_API_TOKEN = process.env.JIRA_API_TOKEN;
+const JIRA_AUTH_TYPE = process.env.JIRA_AUTH_TYPE || "basic";
 
-if (!JIRA_HOST || !JIRA_EMAIL || !JIRA_API_TOKEN) {
+if (!JIRA_HOST || !JIRA_API_TOKEN) {
   throw new Error(
-    "Missing required environment variables: JIRA_HOST, JIRA_EMAIL, and JIRA_API_TOKEN are required"
+    "Missing required environment variables: JIRA_HOST and JIRA_API_TOKEN are required"
+  );
+}
+
+if (JIRA_AUTH_TYPE === "basic" && !JIRA_EMAIL) {
+  throw new Error(
+    "Missing required environment variable for basic auth: JIRA_EMAIL is required"
   );
 }
 
@@ -464,15 +471,21 @@ class JiraServer {
       }
     );
 
-    // Initialize Jira client
-    this.jira = new JiraClient({
+    const jiraConfig: JiraClient.JiraApiOptions = {
       protocol: "https",
       host: JIRA_HOST as string,
-      username: JIRA_EMAIL as string,
-      password: JIRA_API_TOKEN as string,
       apiVersion: "3",
       strictSSL: true,
-    });
+    };
+
+    if (JIRA_AUTH_TYPE === "bearer") {
+      jiraConfig.bearer = JIRA_API_TOKEN as string;
+    } else {
+      jiraConfig.username = JIRA_EMAIL as string;
+      jiraConfig.password = JIRA_API_TOKEN as string;
+    }
+
+    this.jira = new JiraClient(jiraConfig);
 
     this.setupToolHandlers();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ const JIRA_HOST = process.env.JIRA_HOST;
 const JIRA_EMAIL = process.env.JIRA_EMAIL;
 const JIRA_API_TOKEN = process.env.JIRA_API_TOKEN;
 const JIRA_AUTH_TYPE = process.env.JIRA_AUTH_TYPE || "basic";
+const JIRA_API_VERSION = process.env.JIRA_API_VERSION || "3";
 
 if (!JIRA_HOST || !JIRA_API_TOKEN) {
   throw new Error(
@@ -474,7 +475,7 @@ class JiraServer {
     const jiraConfig: JiraClient.JiraApiOptions = {
       protocol: "https",
       host: JIRA_HOST as string,
-      apiVersion: "3",
+      apiVersion: JIRA_API_VERSION,
       strictSSL: true,
     };
 
@@ -772,11 +773,26 @@ class JiraServer {
               ],
             });
 
+            const issues = response.issues || [];
+            const processedIssues = issues.map((issue: any) => {
+              if (
+                issue.fields.description &&
+                typeof issue.fields.description === "object"
+              ) {
+                issue.fields.description = JSON.stringify(
+                  issue.fields.description,
+                  null,
+                  2
+                );
+              }
+              return issue;
+            });
+
             return {
               content: [
                 {
                   type: "text",
-                  text: JSON.stringify(response.issues, null, 2),
+                  text: JSON.stringify(processedIssues, null, 2),
                 },
               ],
             };


### PR DESCRIPTION
This PR address https://github.com/George5562/Jira-MCP-Server/issues/10.

I got the server to work with JIRA server that runs v2 API, not v3 which is used by JIRA cloud.  All the changes are backwards compatible, meaning, default options preserve current behavior.  This PR adds a couple new parameters that allow the user to adjusts the API version and authentication method that is required to make it work with JIRA server.

Summary of updates:

### Authentication Enhancements:
* Added support for PAT authentication by introducing the `JIRA_AUTH_TYPE` environment variable, which can be set to either "basic" (default) or "bearer". Updated the configuration to require `JIRA_EMAIL` only for basic authentication.
* Updated the `README.md` to document the usage of PAT authentication, including setup instructions and configuration examples for `.env` files and MCP server configurations.

### Configuration Improvements:
* Added the optional `JIRA_API_VERSION` environment variable to allow specifying the Jira API version, defaulting to "3". 
* Added `start` script in `package.json` which was documented in the `README.md` but not included in the project configuration.

### Error Handling:
* Enhanced error handling to provide clearer messages when required environment variables are missing, particularly for different authentication types.

### Data Processing:
* Added logic to process Jira issue descriptions that are stored as objects by converting them into a JSON string format for better readability in responses.